### PR TITLE
fix: update jackson-databind to 2.9.7 to fix vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.8.11.2</version>
+			<version>2.9.7</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.8.6</version>
+			<version>2.9.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Fix the vulnerability of "Deserialization of Untrusted Data"
Affecting com.fasterxml.jackson.core:jackson-databind artifact, versions [,2.6.7.1), [2.7,2.7.9.1), [2.8,2.8.9)
Also, com.fasterxml.jackson.core:jackson-core has also been update to 2.9.7