### PR TITLE
fix: programme cannot stop and go to visit many pages and comma in count

### DIFF
--- a/src/main/java/parser/BForumTopicParser.java
+++ b/src/main/java/parser/BForumTopicParser.java
@@ -86,8 +86,19 @@ public class BForumTopicParser {
 			if (content != null) {
 				Document doc = Jsoup.parse(content);
 				Elements elements = doc.select("#threadlist");
+				
+				// if main thread list cannot be found, the forum does not exists
+				if (elements.isEmpty()) {
+					break;
+				}
+				
 				elements = elements.select("tbody[id~=normalthread_[0-9]+]");
 					
+				// exit when threads cannot be found
+				if (elements.isEmpty()) {
+					break;
+				}
+				
 				for (Element element : elements) {					
 					ForumTopic t = new ForumTopic();
 					String checkId = element.attr("id");

--- a/src/main/java/parser/DForumTopicParser.java
+++ b/src/main/java/parser/DForumTopicParser.java
@@ -85,7 +85,18 @@ public class DForumTopicParser {
 			if (content != null) {
 				Document doc = Jsoup.parse(content);
 				Elements elements = doc.select("div.mainbox.threadlist");
+				
+				// if main thread list cannot be found, the forum does not exists
+				if (elements.isEmpty()) {
+					break;
+				}
+				
 				elements = elements.select(".tsubject");
+				
+				// exit when subject cannot be found
+				if (elements.isEmpty()) {
+					break;
+				}
 				
 //				List<URL> topicUrls = new ArrayList<URL>();				
 				for (Element element : elements) {
@@ -116,8 +127,12 @@ public class DForumTopicParser {
 						t.setSubject(subject);
 						t.setAuthor(author);
 						t.setTopicDate(date);
-						t.setReplyCount(new Integer(reply));
-						t.setViewCount(new Integer(view));
+						if (reply != null) {
+							t.setReplyCount(new Integer(reply.replaceAll(",", "")));
+						}
+						if (view != null) {
+							t.setViewCount(new Integer(view.replaceAll(",", "")));
+						}
 						t.setLastPost(lastpost);
 						t.setUrl((new URL(new URL(FORUM_BASE_URL), element.select("a").attr("href")).toString()));						
 						


### PR DESCRIPTION
When there is no content to check in the page, the programme will go to
the next page and check again. And this may lead to an infinite loop.

Now, when there is no content in the first page, we assume the page is
no accessible and will stop.

Fixed to handle the commas in reply and view count